### PR TITLE
[DAT-22724] Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/liquibase_pro_cd_action.yml
+++ b/.github/workflows/liquibase_pro_cd_action.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       # Cancel any previous runs that are not completed for this workflow
       - name: Cancel previous workflow
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/liquibase_pro_manual_deployment.yml
+++ b/.github/workflows/liquibase_pro_manual_deployment.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       # Cancel any previous runs that are not completed for this workflow
       - name: Cancel previous workflow
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/liquibase_pro_rollback_utility_action.yml
+++ b/.github/workflows/liquibase_pro_rollback_utility_action.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       # Cancel any previous runs that are not completed for this workflow
       - name: Cancel previous workflow
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
         with:
           access_token: ${{ github.token }}
 


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full commit SHAs for supply chain security (DAT-21269)

## Test plan
- [ ] Verify workflows run successfully with pinned SHAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)